### PR TITLE
SB-802: Figure out why the Swagger documentation is no longer being generated

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,11 +110,11 @@
             <artifactId>strongbox-web-core</artifactId>
             <version>${project.version}</version>
         </dependency>
-        <!--dependency>
+        <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>strongbox-cron-tasks</artifactId>
             <version>${project.version}</version>
-        </dependency-->
+        </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>strongbox-storage-api-resources</artifactId>
@@ -166,12 +166,12 @@
                     <plugin>
                         <groupId>com.github.kongchen</groupId>
                         <artifactId>swagger-maven-plugin</artifactId>
-                        <version>3.1.3</version>
+                        <version>3.1.4</version>
                         <configuration>
                             <apiSources>
                                 <apiSource>
-                                    <springmvc>false</springmvc>
-                                    <locations>org.carlspring.strongbox.rest</locations>
+                                    <springmvc>true</springmvc>
+                                    <locations>org.carlspring.strongbox.controllers</locations>
                                     <schemes>http,https</schemes>
                                     <host>carlspring.org</host>
                                     <basePath>/strongbox</basePath>


### PR DESCRIPTION
Fixed the documentation. The problem was caused by the fact that the base package for the controllers was renamed (it was pointing to the old Jersey package name). Also, the confiuration was not set up for Spring MVC.